### PR TITLE
Initial fixes to compile with mac

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,7 +1,7 @@
 # point these to absolute paths
-CHARM_DIR = /home/nk/install/release/charm-mpi-smp
-BASE_DIR = /home/nk/projects/LibCharmtyles
-EIGEN_DIR = /usr/include/eigen3
+CHARM_DIR = /Users/advaittahilyani/charm
+BASE_DIR = /Users/advaittahilyani/LibCharmtyles
+EIGEN_DIR = /opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3
 
 # common options
 CHARMC = $(CHARM_DIR)/bin/charmc -DUSE_ESSL_WRAPPER=0

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,7 +1,7 @@
 # point these to absolute paths
-CHARM_DIR = /Users/advaittahilyani/charm
-BASE_DIR = /Users/advaittahilyani/LibCharmtyles
-EIGEN_DIR = /opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3
+CHARM_DIR = /home/nk/install/release/charm-mpi-smp
+BASE_DIR = /home/nk/projects/LibCharmtyles
+EIGEN_DIR = /usr/include/eigen3
 
 # common options
 CHARMC = $(CHARM_DIR)/bin/charmc -DUSE_ESSL_WRAPPER=0

--- a/tests/performance/cg.cpp
+++ b/tests/performance/cg.cpp
@@ -1,4 +1,5 @@
 #include <charmtyles/charmtyles.hpp>
+#include <string>
 
 #include "cg.decl.h"
 
@@ -37,15 +38,15 @@ class Main : public CBase_Main
 public:
     Main(CkArgMsg* msg)
     {
-        int dim = 1 << 14;
+        size_t dim = 1 << 14;
         if (msg->argc > 1)
-            dim = atoi(msg->argv[1]);
+            dim = std::stoull(msg->argv[1]);
 
         ct::init();
         thisProxy.benchmark(dim);
     }
 
-    void benchmark(int dim)
+    void benchmark(size_t dim)
     {
         ckout << "Matrix Dimensions: " << dim << "x" << dim << endl;
         ckout << "Vector Dimensions: " << dim << endl;

--- a/tests/performance/jacobi.cpp
+++ b/tests/performance/jacobi.cpp
@@ -1,10 +1,11 @@
 #include <charmtyles/charmtyles.hpp>
+#include <string>
 
 #include "jacobi.decl.h"
 
 #include <Eigen/Dense>
 
-/* readonly */ int DIMENSION;
+/* readonly */ size_t DIMENSION;
 
 class non_diag_generator : public ct::generator
 {
@@ -71,13 +72,13 @@ public:
     {
         DIMENSION = 1 << 14;
         if (msg->argc > 1)
-            DIMENSION = atoi(msg->argv[1]);
+            DIMENSION = std::stoull(msg->argv[1]);
 
         ct::init();
         thisProxy.benchmark(DIMENSION);
     }
 
-    void benchmark(int dim)
+    void benchmark(size_t dim)
     {
         std::shared_ptr<non_diag_generator> new_non_diag_generator =
             std::make_shared<non_diag_generator>();

--- a/tests/performance/logistic.cpp
+++ b/tests/performance/logistic.cpp
@@ -1,10 +1,11 @@
 #include <charmtyles/charmtyles.hpp>
+#include <string>
 
 #include "logistic.decl.h"
 
 #include <Eigen/Dense>
 
-/* readonly */ int DIMENSION;
+/* readonly */ size_t DIMENSION;
 
 // features -> X_train (Data Points * Num Features)
 // target -> y_train (Data Points)
@@ -110,13 +111,13 @@ public:
     {
         DIMENSION = 1 << 14;
         if (msg->argc > 1)
-            DIMENSION = atoi(msg->argv[1]);
+            DIMENSION = std::stoull(msg->argv[1]);
 
         ct::init();
         thisProxy.benchmark(DIMENSION);
     }
 
-    void benchmark(int dim)
+    void benchmark(size_t dim)
     {
         std::shared_ptr<training_generator> new_training_generator =
             std::make_shared<training_generator>();


### PR DESCRIPTION
Changed all instances of dimension to be size_t rather than int to remove compilation errors.