### PR TITLE
feat: implement inplace operations (add, sub, div)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include Makefile.common
 
-all: libs
+all: libs tests
 
 .PHONY: libs tests clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include Makefile.common
 
-all: libs tests
+all: libs
 
 .PHONY: libs tests clean
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,6 +1,6 @@
 # point these to absolute paths
-CHARM_DIR = /home/ridam_jain61/Documents/UIUC_PPL/charm/netlrts-linux-x86_64
-BASE_DIR = /home/ridam_jain61/Documents/UIUC_PPL/fixed_lbct/LibCharmtyles
+CHARM_DIR = /home/anant/winter2024/lbp/study/charm/netlrts-linux-x86_64-smp
+BASE_DIR = /home/anant/sem7/libcharm_tiles
 EIGEN_DIR = /usr/include/eigen3
 
 # common options

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,6 +1,6 @@
 # point these to absolute paths
-CHARM_DIR = /home/anant/winter2024/lbp/study/charm/netlrts-linux-x86_64-smp
-BASE_DIR = /home/anant/sem7/libcharm_tiles
+CHARM_DIR = /home/shogo/master/Kale/charm/netlrts-linux-x86_64
+BASE_DIR  = /home/shogo/master/Kale/LibCharmtyles
 EIGEN_DIR = /usr/include/eigen3
 
 # common options

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,6 +1,6 @@
 # point these to absolute paths
-CHARM_DIR = /home/shogo/master/Kale/charm/netlrts-linux-x86_64
-BASE_DIR  = /home/shogo/master/Kale/charmTylesUpstream/LibCharmtyles
+CHARM_DIR = /path/to/charm/build/directory
+BASE_DIR  = /path/to/LibCharmtyles
 EIGEN_DIR = /usr/include/eigen3
 
 # common options

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,6 +1,6 @@
 # point these to absolute paths
 CHARM_DIR = /home/shogo/master/Kale/charm/netlrts-linux-x86_64
-BASE_DIR  = /home/shogo/master/Kale/LibCharmtyles
+BASE_DIR  = /home/shogo/master/Kale/charmTylesUpstream/LibCharmtyles
 EIGEN_DIR = /usr/include/eigen3
 
 # common options

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -389,7 +389,6 @@ private:
             }
                 
             return;
-
         case ct::util::Operation::inplace_sub:
             copy_id = node.copy_id_;
             if (node_id == vec_map.size())
@@ -422,7 +421,7 @@ private:
                 else
                     vec_map[node_id][i] -= vec_map[copy_id][i];
             }
-
+            return;
         case ct::util::Operation::inplace_divide:
             copy_id = node.copy_id_;
             if (node_id == vec_map.size())
@@ -456,7 +455,6 @@ private:
                     vec_map[node_id][i] /= vec_map[copy_id][i];
             }
             return;
-
         case ct::util::Operation::unary_expr:
             if (node_id == vec_map.size())
             {

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -365,7 +365,7 @@ private:
             unrolled_size = total_size / 4;
             remainder_start = unrolled_size * 4;
             
-            for (std::size_t i = 0; i != remainder_start; i += 4){
+            for (std::size_t i = 0; i != remainder_start; i += 4) {
                 if (copy_id == static_cast<std::size_t>(-1))
                 {
                     vec_map[node_id][i]     += execute_ast_for_idx(instruction, 1, i);
@@ -750,7 +750,6 @@ private:
         case ct::util::Operation::add:
         case ct::util::Operation::sub:
         case ct::util::Operation::divide:
-            // if the matrix is being declared here
             if (node_id == mat_map.size())
             {
                 num_rows = get_mat_rows(node.mat_row_len_);
@@ -811,16 +810,12 @@ private:
                 for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
                 {
                     if(copy_id == -1) {
-                        mat_map[node_id](i, j) +=
-                            execute_ast_for_idx(instruction, 1, i, j);
-                        mat_map[node_id](i + 1, j) +=
-                            execute_ast_for_idx(instruction, 1, i + 1, j);
-                        mat_map[node_id](i + 2, j) +=
-                            execute_ast_for_idx(instruction, 1, i + 2, j);
-                        mat_map[node_id](i + 3, j) +=
-                            execute_ast_for_idx(instruction, 1, i + 3, j);
+                        mat_map[node_id](i    , j) += execute_ast_for_idx(instruction, 1, i, j);
+                        mat_map[node_id](i + 1, j) += execute_ast_for_idx(instruction, 1, i + 1, j);
+                        mat_map[node_id](i + 2, j) += execute_ast_for_idx(instruction, 1, i + 2, j);
+                        mat_map[node_id](i + 3, j) += execute_ast_for_idx(instruction, 1, i + 3, j);
                     } else {
-                        mat_map[node_id](i, j) += mat_map[copy_id](i, j);
+                        mat_map[node_id](i    , j) += mat_map[copy_id](i, j);
                         mat_map[node_id](i + 1, j) += mat_map[copy_id](i + 1, j);
                         mat_map[node_id](i + 2, j) += mat_map[copy_id](i + 2, j);
                         mat_map[node_id](i + 3, j) += mat_map[copy_id](i + 3, j);
@@ -860,14 +855,14 @@ private:
                 {
                     if (copy_id == static_cast<std::size_t>(-1))
                     {
-                        mat_map[node_id](i, j) -= execute_ast_for_idx(instruction, 1, i,j);
+                        mat_map[node_id](i    , j) -= execute_ast_for_idx(instruction, 1, i,j);
                         mat_map[node_id](i + 1, j) -= execute_ast_for_idx(instruction, 1, i + 1, j);
                         mat_map[node_id](i + 2, j) -= execute_ast_for_idx(instruction, 1, i + 2, j);
                         mat_map[node_id](i + 3, j) -= execute_ast_for_idx(instruction, 1, i + 3, j);
                     }
                     else
                     {
-                        mat_map[node_id](i, j) -= mat_map[copy_id](i,j);
+                        mat_map[node_id](i    , j) -= mat_map[copy_id](i,j);
                         mat_map[node_id](i + 1, j) -= mat_map[copy_id](i + 1, j);
                         mat_map[node_id](i + 2, j) -= mat_map[copy_id](i + 2, j);
                         mat_map[node_id](i + 3, j) -= mat_map[copy_id](i + 3, j);
@@ -907,14 +902,14 @@ private:
                 {
                     if (copy_id == static_cast<std::size_t>(-1))
                     {
-                        mat_map[node_id](i,j)/= execute_ast_for_idx(instruction, 1, i, j);
+                        mat_map[node_id](i    , j) /= execute_ast_for_idx(instruction, 1, i, j);
                         mat_map[node_id](i + 1, j) /= execute_ast_for_idx(instruction, 1, i + 1, j);
-                        mat_map[node_id](i +2, j) /= execute_ast_for_idx(instruction, 1, i + 2, j);
+                        mat_map[node_id](i + 2, j) /= execute_ast_for_idx(instruction, 1, i + 2, j);
                         mat_map[node_id](i + 3, j) /= execute_ast_for_idx(instruction, 1, i + 3, j);
                     }
                     else
                     {
-                        mat_map[node_id](i, j) /= mat_map[copy_id](i, j);
+                        mat_map[node_id](i    , j) /= mat_map[copy_id](i, j);
                         mat_map[node_id](i + 1, j) /= mat_map[copy_id](i + 1, j);
                         mat_map[node_id](i + 2, j) /= mat_map[copy_id](i + 2, j);
                         mat_map[node_id](i + 3, j) /= mat_map[copy_id](i + 3, j);

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -380,7 +380,7 @@ private:
                 }
             }
 
-            for (std::size_t i = remainder_start; i != total_size; i += 4)
+            for (std::size_t i = remainder_start; i != total_size; ++i)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] += execute_ast_for_idx(instruction, 1, i);
@@ -415,7 +415,7 @@ private:
                 }
             }
 
-            for (std::size_t i = remainder_start; i != total_size; i += 4)
+            for (std::size_t i = remainder_start; i != total_size; ++i)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] -= execute_ast_for_idx(instruction, 1, i);
@@ -448,7 +448,7 @@ private:
                 }
             }
 
-            for (std::size_t i = remainder_start; i != total_size; i += 4)
+            for (std::size_t i = remainder_start; i != total_size; ++i)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] /= execute_ast_for_idx(instruction, 1, i);

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -380,7 +380,7 @@ private:
                 }
             }
 
-            for (std::size_t i = 0; i != total_size; i += 4)
+            for (std::size_t i = remainder_start; i != total_size; i += 4)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] += execute_ast_for_idx(instruction, 1, i);
@@ -415,7 +415,7 @@ private:
                 }
             }
 
-            for (std::size_t i = 0; i != total_size; i += 4)
+            for (std::size_t i = remainder_start; i != total_size; i += 4)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] -= execute_ast_for_idx(instruction, 1, i);
@@ -448,7 +448,7 @@ private:
                 }
             }
 
-            for (std::size_t i = 0; i != total_size; i += 4)
+            for (std::size_t i = remainder_start; i != total_size; i += 4)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] /= execute_ast_for_idx(instruction, 1, i);

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -451,9 +451,9 @@ private:
             for (std::size_t i = 0; i != total_size; i += 4)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
-                    safe_div_vec(i, execute_ast_for_idx(instruction, 1, i));
+                    vec_map[node_id][i] /= execute_ast_for_idx(instruction, 1, i);
                 else
-                    safe_div_vec(i, vec_map[copy_id][i]);
+                    vec_map[node_id][i] /= vec_map[copy_id][i];
             }
             return;
 
@@ -832,7 +832,7 @@ private:
             {
                 for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
                 {
-                    if(copy_id == -1)
+                    if(copy_id == std::static_cast<size_t>(-1))
                         mat_map[node_id](i, j) += execute_ast_for_idx(instruction, 1, i, j);
                     else
                         mat_map[node_id](i, j) += mat_map[copy_id](i, j);

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -259,10 +259,6 @@ private:
 
         std::shared_ptr<ct::binary_operator> const& binary_expr =
             node.binary_expr_;
-        auto safe_div_vec = [&](std::size_t idx, double denom) {
-            if (denom != 0.0) vec_map[node_id][idx] /= denom;
-            else CmiAbort("divide by zero");
-        };
 
         std::random_device rd;
         std::mt19937 gen(rd());
@@ -384,7 +380,7 @@ private:
                 }
             }
 
-            for (std::size_t i = 0; i != remainder_start; i += 4)
+            for (std::size_t i = 0; i != total_size; i += 4)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] += execute_ast_for_idx(instruction, 1, i);
@@ -419,7 +415,7 @@ private:
                 }
             }
 
-            for (std::size_t i = 0; i != remainder_start; i += 4)
+            for (std::size_t i = 0; i != total_size; i += 4)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     vec_map[node_id][i] -= execute_ast_for_idx(instruction, 1, i);
@@ -440,19 +436,19 @@ private:
             for (std::size_t i = 0; i != remainder_start; i += 4){
                 if (copy_id == static_cast<std::size_t>(-1))
                 {
-                    safe_div_vec(i, execute_ast_for_idx(instruction, 1, i));
-                    safe_div_vec(i + 1, execute_ast_for_idx(instruction, 1, i + 1));
-                    safe_div_vec(i + 2, execute_ast_for_idx(instruction, 1, i + 2));
-                    safe_div_vec(i + 3, execute_ast_for_idx(instruction, 1, i + 3));
+                    vec_map[node_id][i] /= execute_ast_for_idx(instruction, 1, i);
+                    vec_map[node_id][i + 1] /= execute_ast_for_idx(instruction,1, i + 1);
+                    vec_map[node_id][i + 2] /= execute_ast_for_idx(instruction, 1, i + 2);
+                    vec_map[node_id][i + 3] /= execute_ast_for_idx(instruction, 1, i + 3);
                 } else {
-                    safe_div_vec(i, vec_map[copy_id][i]);
-                    safe_div_vec(i + 1, vec_map[copy_id][i + 1]);
-                    safe_div_vec(i + 2, vec_map[copy_id][i + 2]);
-                    safe_div_vec(i + 3, vec_map[copy_id][i + 3]);
+                    vec_map[node_id][i] /= vec_map[copy_id][i];
+                    vec_map[node_id][i + 1] /= vec_map[copy_id][i + 1];
+                    vec_map[node_id][i + 2] /= vec_map[copy_id][i + 2];
+                    vec_map[node_id][i + 3] /= vec_map[copy_id][i + 3];
                 }
             }
 
-            for (std::size_t i = 0; i != remainder_start; i += 4)
+            for (std::size_t i = 0; i != total_size; i += 4)
             {
                 if (copy_id == static_cast<std::size_t>(-1))
                     safe_div_vec(i, execute_ast_for_idx(instruction, 1, i));
@@ -675,12 +671,6 @@ private:
         std::size_t remainder_start{0};
         std::size_t copy_id{0};
         ct::util::matrix_view mat{};
-        auto safe_div = [&](std::size_t I, std::size_t J, double denom) {
-            if (denom != 0.0) mat_map[node_id](I, J) /= denom;
-            else {
-                CmiAbort("divide by zero");
-            }
-        };
 
         std::random_device rd;
         std::mt19937 gen(rd());
@@ -870,14 +860,14 @@ private:
                 {
                     if (copy_id == static_cast<std::size_t>(-1))
                     {
-                        mat_map[node_id](i, j)     -= execute_ast_for_idx(instruction, 1, i,     j);
+                        mat_map[node_id](i, j) -= execute_ast_for_idx(instruction, 1, i,j);
                         mat_map[node_id](i + 1, j) -= execute_ast_for_idx(instruction, 1, i + 1, j);
                         mat_map[node_id](i + 2, j) -= execute_ast_for_idx(instruction, 1, i + 2, j);
                         mat_map[node_id](i + 3, j) -= execute_ast_for_idx(instruction, 1, i + 3, j);
                     }
                     else
                     {
-                        mat_map[node_id](i, j)     -= mat_map[copy_id](i,     j);
+                        mat_map[node_id](i, j) -= mat_map[copy_id](i,j);
                         mat_map[node_id](i + 1, j) -= mat_map[copy_id](i + 1, j);
                         mat_map[node_id](i + 2, j) -= mat_map[copy_id](i + 2, j);
                         mat_map[node_id](i + 3, j) -= mat_map[copy_id](i + 3, j);
@@ -917,17 +907,17 @@ private:
                 {
                     if (copy_id == static_cast<std::size_t>(-1))
                     {
-                        safe_div(i,     j, execute_ast_for_idx(instruction, 1, i,     j));
-                        safe_div(i + 1, j, execute_ast_for_idx(instruction, 1, i + 1, j));
-                        safe_div(i + 2, j, execute_ast_for_idx(instruction, 1, i + 2, j));
-                        safe_div(i + 3, j, execute_ast_for_idx(instruction, 1, i + 3, j));
+                        mat_map[node_id](i,j)/= execute_ast_for_idx(instruction, 1, i, j);
+                        mat_map[node_id](i + 1, j) /= execute_ast_for_idx(instruction, 1, i + 1, j);
+                        mat_map[node_id](i +2, j) /= execute_ast_for_idx(instruction, 1, i + 2, j);
+                        mat_map[node_id](i + 3, j) /= execute_ast_for_idx(instruction, 1, i + 3, j);
                     }
                     else
                     {
-                        safe_div(i,     j, mat_map[copy_id](i,     j));
-                        safe_div(i + 1, j, mat_map[copy_id](i + 1, j));
-                        safe_div(i + 2, j, mat_map[copy_id](i + 2, j));
-                        safe_div(i + 3, j, mat_map[copy_id](i + 3, j));
+                        mat_map[node_id](i, j) /= mat_map[copy_id](i, j);
+                        mat_map[node_id](i + 1, j) /= mat_map[copy_id](i + 1, j);
+                        mat_map[node_id](i + 2, j) /= mat_map[copy_id](i + 2, j);
+                        mat_map[node_id](i + 3, j) /= mat_map[copy_id](i + 3, j);
                     }
                 }
             }

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -354,7 +354,90 @@ private:
             }
 
             return;
+        case ct::util::Operation::inplace_add:
+            if (node_id == vec_map.size())
+            {
+                vec_dim = get_vec_dim(node.vec_len_);
 
+                vec_map.emplace_back(std::vector<double>(vec_dim));
+            }
+
+            total_size = vec_map[node_id].size();
+            unrolled_size = vec_map[node_id].size() / 4;
+            remainder_start = unrolled_size * 4;
+
+            for (std::size_t i = 0; i != remainder_start; i += 4)
+            {
+                vec_map[node_id][i] += execute_ast_for_idx(instruction, 0, i);
+                vec_map[node_id][i + 1] +=
+                    execute_ast_for_idx(instruction, 0, i + 1);
+                vec_map[node_id][i + 2] +=
+                    execute_ast_for_idx(instruction, 0, i + 2);
+                vec_map[node_id][i + 3] +=
+                    execute_ast_for_idx(instruction, 0, i + 3);
+            }
+
+            for (std::size_t i = remainder_start; i != total_size; ++i)
+            {
+                vec_map[node_id][i] += execute_ast_for_idx(instruction, 0, i);
+            }
+        return;
+        case ct::util::Operation::inplace_sub:
+            if (node_id == vec_map.size())
+            {
+                vec_dim = get_vec_dim(node.vec_len_);
+
+                vec_map.emplace_back(std::vector<double>(vec_dim));
+            }
+
+            total_size = vec_map[node_id].size();
+            unrolled_size = vec_map[node_id].size() / 4;
+            remainder_start = unrolled_size * 4;
+
+            for (std::size_t i = 0; i != remainder_start; i += 4)
+            {
+                vec_map[node_id][i] -= execute_ast_for_idx(instruction, 0, i);
+                vec_map[node_id][i + 1] -=
+                    execute_ast_for_idx(instruction, 0, i + 1);
+                vec_map[node_id][i + 2] -=
+                    execute_ast_for_idx(instruction, 0, i + 2);
+                vec_map[node_id][i + 3] -=
+                    execute_ast_for_idx(instruction, 0, i + 3);
+            }
+
+            for (std::size_t i = remainder_start; i != total_size; ++i)
+            {
+                vec_map[node_id][i] -= execute_ast_for_idx(instruction, 0, i);
+            }
+        return;
+        case ct::util::Operation::inplace_divide:
+            if (node_id == vec_map.size())
+            {
+                vec_dim = get_vec_dim(node.vec_len_);
+
+                vec_map.emplace_back(std::vector<double>(vec_dim));
+            }
+
+            total_size = vec_map[node_id].size();
+            unrolled_size = vec_map[node_id].size() / 4;
+            remainder_start = unrolled_size * 4;
+
+            for (std::size_t i = 0; i != remainder_start; i += 4)
+            {
+                vec_map[node_id][i] /= execute_ast_for_idx(instruction, 0, i);
+                vec_map[node_id][i + 1] /=
+                    execute_ast_for_idx(instruction, 0, i + 1);
+                vec_map[node_id][i + 2] /=
+                    execute_ast_for_idx(instruction, 0, i + 2);
+                vec_map[node_id][i + 3] /=
+                    execute_ast_for_idx(instruction, 0, i + 3);
+            }
+
+            for (std::size_t i = remainder_start; i != total_size; ++i)
+            {
+                vec_map[node_id][i] /= execute_ast_for_idx(instruction, 0, i);
+            }
+        return;
         case ct::util::Operation::unary_expr:
             if (node_id == vec_map.size())
             {
@@ -569,6 +652,12 @@ private:
         std::size_t remainder_start{0};
         std::size_t copy_id{0};
         ct::util::matrix_view mat{};
+        auto safe_div = [&](std::size_t I, std::size_t J, double denom) {
+            if (denom != 0.0) mat_map[node_id](I, J) /= denom;
+            else {
+                CmiAbort("divide by zero");
+            }
+        };
 
         std::random_device rd;
         std::mt19937 gen(rd());
@@ -648,7 +737,7 @@ private:
         case ct::util::Operation::add:
         case ct::util::Operation::sub:
         case ct::util::Operation::divide:
-
+            // if the matrix is being declared here
             if (node_id == mat_map.size())
             {
                 num_rows = get_mat_rows(node.mat_row_len_);
@@ -688,6 +777,148 @@ private:
             }
 
             return;
+        case ct::util::Operation::inplace_add:
+            copy_id = node.copy_id_;  
+            if (node_id == mat_map.size())
+            {
+                num_rows = get_mat_rows(node.mat_row_len_);
+                num_cols = get_mat_cols(node.mat_col_len_);
+
+                mat = ct::util::matrix_view{num_rows, num_cols};
+
+                mat_map.emplace_back(std::move(mat));
+            }
+
+            total_size = mat_map[node_id].rows();
+            unrolled_size = mat_map[node_id].rows() / 4;
+            remainder_start = unrolled_size * 4;
+
+            for (std::size_t i = 0; i != remainder_start; i += 4)
+            {
+                for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
+                {
+                    if(copy_id==-1){
+                        mat_map[node_id](i, j) +=
+                            execute_ast_for_idx(instruction, 1, i, j);
+                        mat_map[node_id](i + 1, j) +=
+                            execute_ast_for_idx(instruction, 1, i + 1, j);
+                        mat_map[node_id](i + 2, j) +=
+                            execute_ast_for_idx(instruction, 1, i + 2, j);
+                        mat_map[node_id](i + 3, j) +=
+                            execute_ast_for_idx(instruction, 1, i + 3, j);
+                    } else{
+                        mat_map[node_id](i, j) += mat_map[copy_id](i, j);
+                        mat_map[node_id](i + 1, j) += mat_map[copy_id](i + 1, j);
+                        mat_map[node_id](i + 2, j) += mat_map[copy_id](i + 2, j);
+                        mat_map[node_id](i + 3, j) += mat_map[copy_id](i + 3, j);
+                    }
+                }
+            }
+
+            for (std::size_t i = remainder_start; i != total_size; ++i)
+            {
+                for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
+                {
+                    mat_map[node_id](i, j) +=
+                        execute_ast_for_idx(instruction, 0, i, j);
+                }
+            }
+
+            return;
+        case ct::util::Operation::inplace_sub:
+            copy_id = node.copy_id_;
+            if (node_id == mat_map.size())
+            {
+                num_rows = get_mat_rows(node.mat_row_len_);
+                num_cols = get_mat_cols(node.mat_col_len_);
+                mat = ct::util::matrix_view{num_rows, num_cols};
+                mat_map.emplace_back(std::move(mat));
+            }
+
+            total_size = mat_map[node_id].rows();
+            unrolled_size = mat_map[node_id].rows() / 4;
+            remainder_start = unrolled_size * 4;
+
+            for (std::size_t i = 0; i != remainder_start; i += 4)
+            {
+                for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
+                {
+                    if (copy_id == static_cast<std::size_t>(-1))
+                    {
+                        mat_map[node_id](i, j)     -= execute_ast_for_idx(instruction, 1, i,     j);
+                        mat_map[node_id](i + 1, j) -= execute_ast_for_idx(instruction, 1, i + 1, j);
+                        mat_map[node_id](i + 2, j) -= execute_ast_for_idx(instruction, 1, i + 2, j);
+                        mat_map[node_id](i + 3, j) -= execute_ast_for_idx(instruction, 1, i + 3, j);
+                    }
+                    else
+                    {
+                        mat_map[node_id](i, j)     -= mat_map[copy_id](i,     j);
+                        mat_map[node_id](i + 1, j) -= mat_map[copy_id](i + 1, j);
+                        mat_map[node_id](i + 2, j) -= mat_map[copy_id](i + 2, j);
+                        mat_map[node_id](i + 3, j) -= mat_map[copy_id](i + 3, j);
+                    }
+                }
+            }
+
+            for (std::size_t i = remainder_start; i != total_size; ++i)
+            {
+                for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
+                {
+                    if (copy_id == static_cast<std::size_t>(-1))
+                        mat_map[node_id](i, j) -= execute_ast_for_idx(instruction, 1, i, j);
+                    else
+                        mat_map[node_id](i, j) -= mat_map[copy_id](i, j);
+                }
+            }
+            return;
+
+        case ct::util::Operation::inplace_divide:
+            copy_id = node.copy_id_;
+            if (node_id == mat_map.size())
+            {
+                num_rows = get_mat_rows(node.mat_row_len_);
+                num_cols = get_mat_cols(node.mat_col_len_);
+                mat = ct::util::matrix_view{num_rows, num_cols};
+                mat_map.emplace_back(std::move(mat));
+            }
+
+            total_size = mat_map[node_id].rows();
+            unrolled_size = mat_map[node_id].rows() / 4;
+            remainder_start = unrolled_size * 4;
+
+            for (std::size_t i = 0; i != remainder_start; i += 4)
+            {
+                for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
+                {
+                    if (copy_id == static_cast<std::size_t>(-1))
+                    {
+                        safe_div(i,     j, execute_ast_for_idx(instruction, 1, i,     j));
+                        safe_div(i + 1, j, execute_ast_for_idx(instruction, 1, i + 1, j));
+                        safe_div(i + 2, j, execute_ast_for_idx(instruction, 1, i + 2, j));
+                        safe_div(i + 3, j, execute_ast_for_idx(instruction, 1, i + 3, j));
+                    }
+                    else
+                    {
+                        safe_div(i,     j, mat_map[copy_id](i,     j));
+                        safe_div(i + 1, j, mat_map[copy_id](i + 1, j));
+                        safe_div(i + 2, j, mat_map[copy_id](i + 2, j));
+                        safe_div(i + 3, j, mat_map[copy_id](i + 3, j));
+                    }
+                }
+            }
+
+            for (std::size_t i = remainder_start; i != total_size; ++i)
+            {
+                for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
+                {
+                    if (copy_id == static_cast<std::size_t>(-1))
+                        safe_div(i, j, execute_ast_for_idx(instruction, 1, i, j));
+                    else
+                        safe_div(i, j, mat_map[copy_id](i, j));
+                }
+            }
+            return;
+
         case ct::util::Operation::unary_expr:
             if (node_id == mat_map.size())
             {

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -832,7 +832,7 @@ private:
             {
                 for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
                 {
-                    if(copy_id == std::static_cast<size_t>(-1))
+                    if(copy_id == static_cast<std::size_t>(-1))
                         mat_map[node_id](i, j) += execute_ast_for_idx(instruction, 1, i, j);
                     else
                         mat_map[node_id](i, j) += mat_map[copy_id](i, j);
@@ -927,9 +927,9 @@ private:
                 for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
                 {
                     if (copy_id == static_cast<std::size_t>(-1))
-                        safe_div(i, j, execute_ast_for_idx(instruction, 1, i, j));
+                        mat_map[node_id](i, j) /= execute_ast_for_idx(instruction, 1, i, j);
                     else
-                        safe_div(i, j, mat_map[copy_id](i, j));
+                        mat_map[node_id](i, j) /= mat_map[copy_id](i, j);
                 }
             }
             return;

--- a/charmtyles/backend/charmtyles_base.hpp
+++ b/charmtyles/backend/charmtyles_base.hpp
@@ -778,7 +778,7 @@ private:
 
             return;
         case ct::util::Operation::inplace_add:
-            copy_id = node.copy_id_;  
+            copy_id = node.copy_id_;
             if (node_id == mat_map.size())
             {
                 num_rows = get_mat_rows(node.mat_row_len_);
@@ -797,7 +797,7 @@ private:
             {
                 for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
                 {
-                    if(copy_id==-1){
+                    if(copy_id == -1) {
                         mat_map[node_id](i, j) +=
                             execute_ast_for_idx(instruction, 1, i, j);
                         mat_map[node_id](i + 1, j) +=
@@ -806,7 +806,7 @@ private:
                             execute_ast_for_idx(instruction, 1, i + 2, j);
                         mat_map[node_id](i + 3, j) +=
                             execute_ast_for_idx(instruction, 1, i + 3, j);
-                    } else{
+                    } else {
                         mat_map[node_id](i, j) += mat_map[copy_id](i, j);
                         mat_map[node_id](i + 1, j) += mat_map[copy_id](i + 1, j);
                         mat_map[node_id](i + 2, j) += mat_map[copy_id](i + 2, j);
@@ -819,8 +819,10 @@ private:
             {
                 for (std::size_t j = 0; j != mat_map[node_id].cols(); ++j)
                 {
-                    mat_map[node_id](i, j) +=
-                        execute_ast_for_idx(instruction, 0, i, j);
+                    if(copy_id == -1)
+                        mat_map[node_id](i, j) += execute_ast_for_idx(instruction, 1, i, j);
+                    else
+                        mat_map[node_id](i, j) += mat_map[copy_id](i, j);
                 }
             }
 

--- a/charmtyles/frontend/matrix.hpp
+++ b/charmtyles/frontend/matrix.hpp
@@ -435,8 +435,7 @@ namespace ct {
             node_.operation_ = ct::util::Operation::inplace_add;
             node_.copy_id_ = other.node_.name_;
 
-            ct::mat_impl::mat_instr_queue_t& queue =
-                CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
+            ct::mat_impl::mat_instr_queue_t& queue = CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
 
             queue.insert(node_, matrix_shape_.shape_id);
 
@@ -537,9 +536,8 @@ namespace ct {
             
             root.name_ = matrix_shape_.matrix_id;
 
-            // make new dummy root and emplace it at the front
-            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_add,
-                row_size_, col_size_};
+            // make new root to account for the inplace operation
+            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_add, row_size_, col_size_};
             new_root.left_ = -1;
             new_root.right_ = 1;
             new_root.mat_row_len_ = row_size_;
@@ -547,7 +545,7 @@ namespace ct {
             new_root.name_ = matrix_shape_.matrix_id;
             instr.insert(instr.begin(), new_root);
 
-            //make all the left and right if not -1 +=1 foe the other nodes
+            // increment the indices by 1 to account for the new node added
             for (std::size_t i = 1; i < instr.size(); ++i)
             {
                 if (instr[i].left_ != static_cast<std::size_t>(-1))
@@ -578,9 +576,7 @@ namespace ct {
             
             root.name_ = matrix_shape_.matrix_id;
 
-            // make new dummy root and emplace it at the front
-            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_sub,
-                row_size_, col_size_};
+            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_sub, row_size_, col_size_};
             new_root.left_ = -1;
             new_root.right_ = 1;
             new_root.mat_row_len_ = row_size_;
@@ -588,7 +584,6 @@ namespace ct {
             new_root.name_ = matrix_shape_.matrix_id;
             instr.insert(instr.begin(), new_root);
 
-            //make all the left and right if not -1 +=1 foe the other nodes
             for (std::size_t i = 1; i < instr.size(); ++i)
             {
                 if (instr[i].left_ != static_cast<std::size_t>(-1))
@@ -619,9 +614,7 @@ namespace ct {
             
             root.name_ = matrix_shape_.matrix_id;
 
-            // make new dummy root and emplace it at the front
-            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_divide,
-                row_size_, col_size_};
+            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_divide, row_size_, col_size_};
             new_root.left_ = -1;
             new_root.right_ = 1;
             new_root.mat_row_len_ = row_size_;
@@ -629,7 +622,6 @@ namespace ct {
             new_root.name_ = matrix_shape_.matrix_id;
             instr.insert(instr.begin(), new_root);
 
-            //make all the left and right if not -1 +=1 foe the other nodes
             for (std::size_t i = 1; i < instr.size(); ++i)
             {
                 if (instr[i].left_ != static_cast<std::size_t>(-1))

--- a/charmtyles/frontend/matrix.hpp
+++ b/charmtyles/frontend/matrix.hpp
@@ -560,10 +560,7 @@ namespace ct {
             
             ct::mat_impl::mat_instr_queue_t& queue =
             CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
-            queue.print_instructions();
-            
             queue.insert(instr, matrix_shape_.shape_id);
-            queue.print_instructions();
 
             return *this;
         }
@@ -598,10 +595,7 @@ namespace ct {
             
             ct::mat_impl::mat_instr_queue_t& queue =
             CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
-            queue.print_instructions();
-            
             queue.insert(instr, matrix_shape_.shape_id);
-            queue.print_instructions();
 
             return *this;
         }
@@ -636,10 +630,7 @@ namespace ct {
             
             ct::mat_impl::mat_instr_queue_t& queue =
             CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
-            queue.print_instructions();
-            
             queue.insert(instr, matrix_shape_.shape_id);
-            queue.print_instructions();
 
             return *this;
         }

--- a/charmtyles/frontend/matrix.hpp
+++ b/charmtyles/frontend/matrix.hpp
@@ -430,6 +430,45 @@ namespace ct {
             return *this;
         }
 
+        matrix& operator+=(matrix const& other)
+        {
+            node_.operation_ = ct::util::Operation::inplace_add;
+            node_.copy_id_ = other.node_.name_;
+
+            ct::mat_impl::mat_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
+
+            queue.insert(node_, matrix_shape_.shape_id);
+
+            return *this;
+        }
+
+        matrix& operator-=(matrix const& other)
+        {
+            node_.operation_ = ct::util::Operation::inplace_sub;
+            node_.copy_id_ = other.node_.name_;
+
+            ct::mat_impl::mat_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
+
+            queue.insert(node_, matrix_shape_.shape_id);
+
+            return *this;
+        }
+
+        matrix& operator/=(matrix const& other)
+        {
+            node_.operation_ = ct::util::Operation::inplace_divide;
+            node_.copy_id_ = other.node_.name_;
+
+            ct::mat_impl::mat_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
+
+            queue.insert(node_, matrix_shape_.shape_id);
+
+            return *this;
+        }
+
         // TODO: Figure out why this is necessary!
         matrix(matrix&& other)
           : row_size_(other.row_size_)
@@ -486,6 +525,129 @@ namespace ct {
                 CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
 
             queue.insert(instr, matrix_shape_.shape_id);
+
+            return *this;
+        }
+
+        template <typename LHS, typename RHS>
+        matrix& operator+=(ct::mat_impl::mat_expression<LHS, RHS> const& e)
+        {
+            std::vector<ct::mat_impl::mat_node> instr = e();
+            ct::mat_impl::mat_node& root = instr.front();
+            
+            root.name_ = matrix_shape_.matrix_id;
+
+            // make new dummy root and emplace it at the front
+            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_add,
+                row_size_, col_size_};
+            new_root.left_ = -1;
+            new_root.right_ = 1;
+            new_root.mat_row_len_ = row_size_;
+            new_root.mat_col_len_ = col_size_;
+            new_root.name_ = matrix_shape_.matrix_id;
+            instr.insert(instr.begin(), new_root);
+
+            //make all the left and right if not -1 +=1 foe the other nodes
+            for (std::size_t i = 1; i < instr.size(); ++i)
+            {
+                if (instr[i].left_ != static_cast<std::size_t>(-1))
+                {
+                    instr[i].left_ += 1;
+                }
+                if (instr[i].right_ != static_cast<std::size_t>(-1))
+                {   
+                    instr[i].right_ += 1;
+                }
+            }
+            
+            ct::mat_impl::mat_instr_queue_t& queue =
+            CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
+            queue.print_instructions();
+            
+            queue.insert(instr, matrix_shape_.shape_id);
+            queue.print_instructions();
+
+            return *this;
+        }
+
+        template <typename LHS, typename RHS>
+        matrix& operator-=(ct::mat_impl::mat_expression<LHS, RHS> const& e)
+        {
+            std::vector<ct::mat_impl::mat_node> instr = e();
+            ct::mat_impl::mat_node& root = instr.front();
+            
+            root.name_ = matrix_shape_.matrix_id;
+
+            // make new dummy root and emplace it at the front
+            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_sub,
+                row_size_, col_size_};
+            new_root.left_ = -1;
+            new_root.right_ = 1;
+            new_root.mat_row_len_ = row_size_;
+            new_root.mat_col_len_ = col_size_;
+            new_root.name_ = matrix_shape_.matrix_id;
+            instr.insert(instr.begin(), new_root);
+
+            //make all the left and right if not -1 +=1 foe the other nodes
+            for (std::size_t i = 1; i < instr.size(); ++i)
+            {
+                if (instr[i].left_ != static_cast<std::size_t>(-1))
+                {
+                    instr[i].left_ += 1;
+                }
+                if (instr[i].right_ != static_cast<std::size_t>(-1))
+                {   
+                    instr[i].right_ += 1;
+                }
+            }
+            
+            ct::mat_impl::mat_instr_queue_t& queue =
+            CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
+            queue.print_instructions();
+            
+            queue.insert(instr, matrix_shape_.shape_id);
+            queue.print_instructions();
+
+            return *this;
+        }
+        
+        template <typename LHS, typename RHS>
+        matrix& operator/=(ct::mat_impl::mat_expression<LHS, RHS> const& e)
+        {
+            std::vector<ct::mat_impl::mat_node> instr = e();
+            ct::mat_impl::mat_node& root = instr.front();
+            
+            root.name_ = matrix_shape_.matrix_id;
+
+            // make new dummy root and emplace it at the front
+            ct::mat_impl::mat_node new_root{ct::util::Operation::inplace_divide,
+                row_size_, col_size_};
+            new_root.left_ = -1;
+            new_root.right_ = 1;
+            new_root.mat_row_len_ = row_size_;
+            new_root.mat_col_len_ = col_size_;
+            new_root.name_ = matrix_shape_.matrix_id;
+            instr.insert(instr.begin(), new_root);
+
+            //make all the left and right if not -1 +=1 foe the other nodes
+            for (std::size_t i = 1; i < instr.size(); ++i)
+            {
+                if (instr[i].left_ != static_cast<std::size_t>(-1))
+                {
+                    instr[i].left_ += 1;
+                }
+                if (instr[i].right_ != static_cast<std::size_t>(-1))
+                {   
+                    instr[i].right_ += 1;
+                }
+            }
+            
+            ct::mat_impl::mat_instr_queue_t& queue =
+            CT_ACCESS_SINGLETON(ct::mat_impl::mat_instr_queue);
+            queue.print_instructions();
+            
+            queue.insert(instr, matrix_shape_.shape_id);
+            queue.print_instructions();
 
             return *this;
         }

--- a/charmtyles/frontend/vector.hpp
+++ b/charmtyles/frontend/vector.hpp
@@ -464,7 +464,6 @@ namespace ct {
         vector& operator=(
             ct::binary_impl::binary_expression<LeftOperand, RightOperand> const& e);
 
-        // In-place ops with another vector
         vector& operator+=(vector const& other)
         {
             node_.operation_ = ct::util::Operation::inplace_add;
@@ -495,7 +494,6 @@ namespace ct {
             return *this;
         }
 
-        // In-place ops with expression (E must yield AST like existing + / -)
         template <typename LHS, typename RHS>
         vector& operator+=(ct::vec_impl::vec_expression<LHS, RHS> const& e)
         {
@@ -508,7 +506,7 @@ namespace ct {
             instr.insert(instr.begin(), root);
             for (std::size_t i = 1; i < instr.size(); ++i)
             {
-                if (instr[i].left_ != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
+                if (instr[i].left_  != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
                 if (instr[i].right_ != static_cast<std::size_t>(-1)) instr[i].right_ += 1;
             }
             ct::vec_impl::vec_instr_queue_t& queue =
@@ -529,7 +527,7 @@ namespace ct {
             instr.insert(instr.begin(), root);
             for (std::size_t i = 1; i < instr.size(); ++i)
             {
-                if (instr[i].left_ != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
+                if (instr[i].left_  != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
                 if (instr[i].right_ != static_cast<std::size_t>(-1)) instr[i].right_ += 1;
             }
             ct::vec_impl::vec_instr_queue_t& queue =
@@ -550,7 +548,7 @@ namespace ct {
             instr.insert(instr.begin(), root);
             for (std::size_t i = 1; i < instr.size(); ++i)
             {
-                if (instr[i].left_ != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
+                if (instr[i].left_  != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
                 if (instr[i].right_ != static_cast<std::size_t>(-1)) instr[i].right_ += 1;
             }
             ct::vec_impl::vec_instr_queue_t& queue =

--- a/charmtyles/frontend/vector.hpp
+++ b/charmtyles/frontend/vector.hpp
@@ -464,6 +464,101 @@ namespace ct {
         vector& operator=(
             ct::binary_impl::binary_expression<LeftOperand, RightOperand> const& e);
 
+        // In-place ops with another vector
+        vector& operator+=(vector const& other)
+        {
+            node_.operation_ = ct::util::Operation::inplace_add;
+            node_.copy_id_ = other.node_.name_;
+            ct::vec_impl::vec_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+            queue.insert(node_, vector_shape_.shape_id);
+            return *this;
+        }
+
+        vector& operator-=(vector const& other)
+        {
+            node_.operation_ = ct::util::Operation::inplace_sub;
+            node_.copy_id_ = other.node_.name_;
+            ct::vec_impl::vec_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+            queue.insert(node_, vector_shape_.shape_id);
+            return *this;
+        }
+
+        vector& operator/=(vector const& other)
+        {
+            node_.operation_ = ct::util::Operation::inplace_divide;
+            node_.copy_id_ = other.node_.name_;
+            ct::vec_impl::vec_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+            queue.insert(node_, vector_shape_.shape_id);
+            return *this;
+        }
+
+        // In-place ops with expression (E must yield AST like existing + / -)
+        template <typename LHS, typename RHS>
+        vector& operator+=(ct::vec_impl::vec_expression<LHS, RHS> const& e)
+        {
+            auto instr = e();
+            instr.front().name_ = vector_shape_.vector_id;
+            ct::vec_impl::vec_node root{ct::util::Operation::inplace_add, size_};
+            root.left_ = static_cast<std::size_t>(-1);
+            root.right_ = 1;
+            root.name_ = vector_shape_.vector_id;
+            instr.insert(instr.begin(), root);
+            for (std::size_t i = 1; i < instr.size(); ++i)
+            {
+                if (instr[i].left_ != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
+                if (instr[i].right_ != static_cast<std::size_t>(-1)) instr[i].right_ += 1;
+            }
+            ct::vec_impl::vec_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+            queue.insert(instr, vector_shape_.shape_id);
+            return *this;
+        }
+
+        template <typename LHS, typename RHS>
+        vector& operator-=(ct::vec_impl::vec_expression<LHS, RHS> const& e)
+        {
+            auto instr = e();
+            instr.front().name_ = vector_shape_.vector_id;
+            ct::vec_impl::vec_node root{ct::util::Operation::inplace_sub, size_};
+            root.left_ = static_cast<std::size_t>(-1);
+            root.right_ = 1;
+            root.name_ = vector_shape_.vector_id;
+            instr.insert(instr.begin(), root);
+            for (std::size_t i = 1; i < instr.size(); ++i)
+            {
+                if (instr[i].left_ != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
+                if (instr[i].right_ != static_cast<std::size_t>(-1)) instr[i].right_ += 1;
+            }
+            ct::vec_impl::vec_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+            queue.insert(instr, vector_shape_.shape_id);
+            return *this;
+        }
+
+        template <typename LHS, typename RHS>
+        vector& operator/=(ct::vec_impl::vec_expression<LHS, RHS> const& e)
+        {
+            auto instr = e();
+            instr.front().name_ = vector_shape_.vector_id;
+            ct::vec_impl::vec_node root{ct::util::Operation::inplace_divide, size_};
+            root.left_ = static_cast<std::size_t>(-1);
+            root.right_ = 1;
+            root.name_ = vector_shape_.vector_id;
+            instr.insert(instr.begin(), root);
+            for (std::size_t i = 1; i < instr.size(); ++i)
+            {
+                if (instr[i].left_ != static_cast<std::size_t>(-1)) instr[i].left_ += 1;
+                if (instr[i].right_ != static_cast<std::size_t>(-1)) instr[i].right_ += 1;
+            }
+            ct::vec_impl::vec_instr_queue_t& queue =
+                CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+            queue.insert(instr, vector_shape_.shape_id);
+            return *this;
+        }
+
         // Helper functions
     public:
         const ct::vec_impl::vec_shape_t vector_shape() const

--- a/charmtyles/util/AST.hpp
+++ b/charmtyles/util/AST.hpp
@@ -24,6 +24,9 @@ namespace ct {
             add = 10,
             sub = 11,
             divide = 12,
+            inplace_add = 13,
+            inplace_sub = 14,
+            inplace_divide = 15,
 
             // Blas
             axpy = 20,
@@ -54,6 +57,21 @@ namespace ct {
         template <typename ASTNode>
         void parse_ast(std::vector<ASTNode> const& instr, std::size_t index)
         {
+            if (index ==0 && instr[index].operation_ == ct::util::Operation::inplace_add){
+                ckout << instr[index].name_ << " += ";
+                parse_ast(instr, instr[index].right_);
+                return;
+            }
+            if (index ==0 && instr[index].operation_ == ct::util::Operation::inplace_sub){
+                ckout << instr[index].name_ << " -= ";
+                parse_ast(instr, instr[index].right_);
+                return;
+            }
+            if (index == 0 && instr[index].operation_ == ct::util::Operation::inplace_divide){
+                ckout << instr[index].name_ << " /= ";
+                parse_ast(instr, instr[index].right_);
+                return;
+            }
             if (index == 0 && !is_init_type(instr[index].operation_))
                 ckout << instr[index].name_ << " = ";
 

--- a/charmtyles/util/AST.hpp
+++ b/charmtyles/util/AST.hpp
@@ -57,12 +57,12 @@ namespace ct {
         template <typename ASTNode>
         void parse_ast(std::vector<ASTNode> const& instr, std::size_t index)
         {
-            if (index ==0 && instr[index].operation_ == ct::util::Operation::inplace_add){
+            if (index == 0 && instr[index].operation_ == ct::util::Operation::inplace_add){
                 ckout << instr[index].name_ << " += ";
                 parse_ast(instr, instr[index].right_);
                 return;
             }
-            if (index ==0 && instr[index].operation_ == ct::util::Operation::inplace_sub){
+            if (index == 0 && instr[index].operation_ == ct::util::Operation::inplace_sub){
                 ckout << instr[index].name_ << " -= ";
                 parse_ast(instr, instr[index].right_);
                 return;

--- a/tests/matrix/matrix.cpp
+++ b/tests/matrix/matrix.cpp
@@ -60,6 +60,9 @@ public:
         mat14 = mat11 - mat13 + mat14;
         mat114 = mat111 - mat113 + mat114;
 
+        // in-place operation
+        ct::matrix mat115 += mat111 += mat112 - mat113;
+
         ct::sync();
         end = CkWallTimer();
 

--- a/tests/matrix/matrix.cpp
+++ b/tests/matrix/matrix.cpp
@@ -61,7 +61,8 @@ public:
         mat114 = mat111 - mat113 + mat114;
 
         // in-place operation
-        ct::matrix mat115 += mat111 += mat112 - mat113;
+        ct::matrix mat115 = mat112 -= mat113;
+        mat115 += mat111 += mat112;
 
         ct::sync();
         end = CkWallTimer();

--- a/tests/vector/vector.cpp
+++ b/tests/vector/vector.cpp
@@ -58,7 +58,8 @@ public:
         vec114 = vec111 - vec113 + vec114;
 
         // in-place operation
-        ct::vector vec115 += vec111 += vec112 - vec113;
+        ct::vector vec115 = vec112 -= vec113;
+        vec115 += vec111 += vec112;
 
         ct::sync();
         end = CkWallTimer();

--- a/tests/vector/vector.cpp
+++ b/tests/vector/vector.cpp
@@ -57,6 +57,9 @@ public:
         vec14 = vec11 - vec13 + vec14;
         vec114 = vec111 - vec113 + vec114;
 
+        // in-place operation
+        ct::vector vec115 += vec111 += vec112 - vec113;
+
         ct::sync();
         end = CkWallTimer();
 

--- a/tests/vector/vector.cpp
+++ b/tests/vector/vector.cpp
@@ -18,75 +18,80 @@ public:
 
     void benchmark()
     {
-        constexpr std::size_t vec_size_1 = 1 << 20;
-        constexpr std::size_t vec_size_2 = 1 << 26;
-        constexpr std::size_t vec_size_3 = 1 << 22;
+        constexpr std::size_t vec_size_1 = 4;
+        constexpr std::size_t vec_size_2 = 3;
+        constexpr std::size_t vec_size_3 = 2;
 
         double start = CkWallTimer();
 
-        ct::vector vec1{vec_size_1};
+        ct::vector vec1{vec_size_1,1};
         ct::vector vec2{vec_size_1, 1.5};
         ct::vector vec3{vec_size_1, .5};
+        ct::vector vec4{vec_size_1,1};
 
-        ct::vector vec4 = vec1 + vec2 - vec3;
+        vec4 += vec1 + vec2 - vec3;
 
-        ct::vector vec11{vec_size_2};
-        ct::vector vec12{vec_size_2, 1.5};
-        ct::vector vec13{vec_size_2, .5};
+        // ct::vector vec11{vec_size_2};
+        // ct::vector vec12{vec_size_2, 1.5};
+        // ct::vector vec13{vec_size_2, .5};
 
-        ct::vector vec14 = vec11 + vec12 - vec13;
+        // ct::vector vec14 = vec11 + vec12 - vec13;
 
-        ct::vector vec111{vec_size_3};
-        ct::vector vec112{vec_size_3, 1.5};
-        ct::vector vec113{vec_size_3, .5};
+        // ct::vector vec111{vec_size_3};
+        // ct::vector vec112{vec_size_3, 1.5};
+        // ct::vector vec113{vec_size_3, .5};
 
-        ct::vector vec114 = vec111 + vec112 - vec113;
+        // ct::vector vec114 = vec111 + vec112 - vec113;
 
-        // ct::vec_impl::vec_instr_queue_t& queue =
-        //     CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
-        // queue.print_instructions();
+        // // ct::vec_impl::vec_instr_queue_t& queue =
+        // //     CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+        // // queue.print_instructions();
+
+        // ct::sync();
+
+        // double end = CkWallTimer();
+
+        // ckout << "Execution Time (Phase 1): " << end - start << endl;
+
+        // start = CkWallTimer();
+        // vec4 = vec1 - vec3 + vec4;
+        // vec14 = vec11 - vec13 + vec14;
+        // vec114 = vec111 - vec113 + vec114;
+
+        // ct::sync();
+        // end = CkWallTimer();
+
+        // ckout << "Execution Time (Phase 2): " << end - start << endl;
+
+        // // copy operator
+        // vec4 = vec1;
+        // // copy constructor
+        // ct::vector vec5 = vec4;
 
         ct::sync();
 
-        double end = CkWallTimer();
+        // ct::vector x{1 << 21, 1.0};
+        // ct::vector y{1 << 21, 2.0};
+        // ct::scalar scal1 = ct::dot(x, y);
+        // double underlying_val = scal1.get();
 
-        ckout << "Execution Time (Phase 1): " << end - start << endl;
+        // ckout << "Result of Vector dot product: " << underlying_val << endl;
 
-        start = CkWallTimer();
-        vec4 = vec1 - vec3 + vec4;
-        vec14 = vec11 - vec13 + vec14;
-        vec114 = vec111 - vec113 + vec114;
-
-        ct::sync();
-        end = CkWallTimer();
-
-        ckout << "Execution Time (Phase 2): " << end - start << endl;
-
-        // copy operator
-        vec4 = vec1;
-        // copy constructor
-        ct::vector vec5 = vec4;
-
-        ct::sync();
-
-        ct::vector x{1 << 21, 1.0};
-        ct::vector y{1 << 21, 2.0};
-        ct::scalar scal1 = ct::dot(x, y);
-        double underlying_val = scal1.get();
-
-        ckout << "Result of Vector dot product: " << underlying_val << endl;
-
-        // Test our new from_vector functionality
-        std::vector<double> test_data = {1.1, 2.2, 3.3, 4.4, 5.5};
-        ct::vector custom_vec = ct::from_vector(test_data);
-        ct::sync();
+        // // Test our new from_vector functionality
+        // std::vector<double> test_data = {1.1, 2.2, 3.3, 4.4, 5.5};
+        // ct::vector custom_vec = ct::from_vector(test_data);
+        // ct::sync();
         
-        std::vector<double> result = custom_vec.get();
-        ckout << "Custom vector elements: ";
-        for (const auto& val : result) {
-            ckout << val << " ";
+        // std::vector<double> result = custom_vec.get();
+        // ckout << "Custom vector elements: ";
+        // for (const auto& val : result) {
+        //     ckout << val << " ";
+        // }
+        // ckout << endl;
+        for(auto it:vec4.get()){
+            ckout<<it<<" ";
         }
-        ckout << endl;
+        ckout<<endl;
 
         CkExit();
     }

--- a/tests/vector/vector.cpp
+++ b/tests/vector/vector.cpp
@@ -18,80 +18,75 @@ public:
 
     void benchmark()
     {
-        constexpr std::size_t vec_size_1 = 4;
-        constexpr std::size_t vec_size_2 = 3;
-        constexpr std::size_t vec_size_3 = 2;
+        constexpr std::size_t vec_size_1 = 1 << 20;
+        constexpr std::size_t vec_size_2 = 1 << 26;
+        constexpr std::size_t vec_size_3 = 1 << 22;
 
         double start = CkWallTimer();
 
-        ct::vector vec1{vec_size_1,1};
+        ct::vector vec1{vec_size_1};
         ct::vector vec2{vec_size_1, 1.5};
         ct::vector vec3{vec_size_1, .5};
-        ct::vector vec4{vec_size_1,1};
 
-        vec4 += vec1 + vec2 - vec3;
+        ct::vector vec4 = vec1 + vec2 - vec3;
 
-        // ct::vector vec11{vec_size_2};
-        // ct::vector vec12{vec_size_2, 1.5};
-        // ct::vector vec13{vec_size_2, .5};
+        ct::vector vec11{vec_size_2};
+        ct::vector vec12{vec_size_2, 1.5};
+        ct::vector vec13{vec_size_2, .5};
 
-        // ct::vector vec14 = vec11 + vec12 - vec13;
+        ct::vector vec14 = vec11 + vec12 - vec13;
 
-        // ct::vector vec111{vec_size_3};
-        // ct::vector vec112{vec_size_3, 1.5};
-        // ct::vector vec113{vec_size_3, .5};
+        ct::vector vec111{vec_size_3};
+        ct::vector vec112{vec_size_3, 1.5};
+        ct::vector vec113{vec_size_3, .5};
 
-        // ct::vector vec114 = vec111 + vec112 - vec113;
+        ct::vector vec114 = vec111 + vec112 - vec113;
 
-        // // ct::vec_impl::vec_instr_queue_t& queue =
-        // //     CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
-        // // queue.print_instructions();
-
-        // ct::sync();
-
-        // double end = CkWallTimer();
-
-        // ckout << "Execution Time (Phase 1): " << end - start << endl;
-
-        // start = CkWallTimer();
-        // vec4 = vec1 - vec3 + vec4;
-        // vec14 = vec11 - vec13 + vec14;
-        // vec114 = vec111 - vec113 + vec114;
-
-        // ct::sync();
-        // end = CkWallTimer();
-
-        // ckout << "Execution Time (Phase 2): " << end - start << endl;
-
-        // // copy operator
-        // vec4 = vec1;
-        // // copy constructor
-        // ct::vector vec5 = vec4;
+        // ct::vec_impl::vec_instr_queue_t& queue =
+        //     CT_ACCESS_SINGLETON(ct::vec_impl::vec_instr_queue);
+        // queue.print_instructions();
 
         ct::sync();
 
-        // ct::vector x{1 << 21, 1.0};
-        // ct::vector y{1 << 21, 2.0};
-        // ct::scalar scal1 = ct::dot(x, y);
-        // double underlying_val = scal1.get();
+        double end = CkWallTimer();
 
-        // ckout << "Result of Vector dot product: " << underlying_val << endl;
+        ckout << "Execution Time (Phase 1): " << end - start << endl;
 
-        // // Test our new from_vector functionality
-        // std::vector<double> test_data = {1.1, 2.2, 3.3, 4.4, 5.5};
-        // ct::vector custom_vec = ct::from_vector(test_data);
-        // ct::sync();
+        start = CkWallTimer();
+        vec4 = vec1 - vec3 + vec4;
+        vec14 = vec11 - vec13 + vec14;
+        vec114 = vec111 - vec113 + vec114;
+
+        ct::sync();
+        end = CkWallTimer();
+
+        ckout << "Execution Time (Phase 2): " << end - start << endl;
+
+        // copy operator
+        vec4 = vec1;
+        // copy constructor
+        ct::vector vec5 = vec4;
+
+        ct::sync();
+
+        ct::vector x{1 << 21, 1.0};
+        ct::vector y{1 << 21, 2.0};
+        ct::scalar scal1 = ct::dot(x, y);
+        double underlying_val = scal1.get();
+
+        ckout << "Result of Vector dot product: " << underlying_val << endl;
+
+        // Test our new from_vector functionality
+        std::vector<double> test_data = {1.1, 2.2, 3.3, 4.4, 5.5};
+        ct::vector custom_vec = ct::from_vector(test_data);
+        ct::sync();
         
-        // std::vector<double> result = custom_vec.get();
-        // ckout << "Custom vector elements: ";
-        // for (const auto& val : result) {
-        //     ckout << val << " ";
-        // }
-        // ckout << endl;
-        for(auto it:vec4.get()){
-            ckout<<it<<" ";
+        std::vector<double> result = custom_vec.get();
+        ckout << "Custom vector elements: ";
+        for (const auto& val : result) {
+            ckout << val << " ";
         }
-        ckout<<endl;
+        ckout << endl;
 
         CkExit();
     }


### PR DESCRIPTION
PR to add support for inplace ops. There are 2 variants, one where the RHS is a mat/vec expression and the other where it is a proper matrix/vector. The former is identical to how arith ops like add/sub are handled while the latter is identical to how the copy operation is handled. 